### PR TITLE
Added the img directory to the main section of bower.json so that gul…

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -18,7 +18,8 @@
   ],
   "main": [
     "./dist/angular-awesome-slider.js",
-    "./dist/css/angular-awesome-slider.min.css"
+    "./dist/css/angular-awesome-slider.min.css",
+    "./dist/img/*"
   ],
   "dependencies": {
     "angular": "^1.3.x"


### PR DESCRIPTION
Added the img directory to the "main" section of bower.json so that gulp's main-bower-files task will run correctly. main-bower-files uses the entries in the "main" section to create its list of source files to pipe to the next gulp task. All other files are ignored.